### PR TITLE
fix: remove save emoji

### DIFF
--- a/austin_tui/controller.py
+++ b/austin_tui/controller.py
@@ -260,7 +260,7 @@ class AustinTUIController:
                             fout.write(line + "\n")
                 self.view.notification.set_text(
                     self.view.markup(
-                        f"Stats saved as <running>{escape(filename)}</running> 📝 "
+                        f"Stats saved as <running>{escape(filename)}</running> "
                     )
                 )
             except IOError as e:


### PR DESCRIPTION
### Description of the Change

As reported in #20, the emoji displayed when data is saved to file causes issues. As this is not a vital feature, we are removing it for the sake of better compatibility on MacOS.

Fixes #20.

### Alternate Designs

n/a

### Regressions

n/a

### Verification Process

Existing test suite