### PR TITLE
fix: change coroutine to task (#28)

### DIFF
--- a/austin_tui/view/__init__.py
+++ b/austin_tui/view/__init__.py
@@ -149,8 +149,10 @@ class View(ABC):
                     event = self.root_widget._win.getkey()
                     if event in self._event_handlers:
                         done, pending = await asyncio.wait(
-                            [asyncio.create_task(_())
-                                for _ in self._event_handlers[event]]
+                            [
+                                asyncio.create_task(_())
+                                for _ in self._event_handlers[event]
+                            ]
                         )
                         assert not pending
                         if any(_.result() for _ in done):

--- a/austin_tui/view/__init__.py
+++ b/austin_tui/view/__init__.py
@@ -149,7 +149,8 @@ class View(ABC):
                     event = self.root_widget._win.getkey()
                     if event in self._event_handlers:
                         done, pending = await asyncio.wait(
-                            [_() for _ in self._event_handlers[event]]
+                            [asyncio.ensure_future(_())
+                                for _ in self._event_handlers[event]]
                         )
                         assert not pending
                         if any(_.result() for _ in done):

--- a/austin_tui/view/__init__.py
+++ b/austin_tui/view/__init__.py
@@ -149,7 +149,7 @@ class View(ABC):
                     event = self.root_widget._win.getkey()
                     if event in self._event_handlers:
                         done, pending = await asyncio.wait(
-                            [asyncio.ensure_future(_())
+                            [asyncio.create_task(_())
                                 for _ in self._event_handlers[event]]
                         )
                         assert not pending


### PR DESCRIPTION
### Requirements for Adding, Changing, Fixing or Removing a Feature

Fill out the template below. Any pull request that does not include enough
information to be reviewed in a timely manner may be closed at the maintainers'
discretion.


### Description of the Change

In Python 3.11, you must await tasks instead of coroutines. This change simply wraps the coroutine with `create_task`.

### Alternate Designs

The fix was originally to use `ensure_future`, but that was deprecated in Python 3.10.

### Regressions

None that I'm aware of.

### Verification Process

Interactive testing. Prior to the fix, any keyboard input crashed the UI.
