### PR TITLE
feat: dump stats to MOJO format

### DIFF
--- a/austin_tui/adapters.py
+++ b/austin_tui/adapters.py
@@ -20,23 +20,18 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Any
-from typing import Optional
-from typing import Union
+from typing import Any, Optional, Union
 
+from austin.events import ThreadName
 from austin.stats import HierarchicalStats
 
 from austin_tui import AustinProfileMode
 from austin_tui.model import Model
 from austin_tui.model.austin import AustinModel
-from austin_tui.model.system import Bytes
-from austin_tui.model.system import FrozenSystemModel
-from austin_tui.model.system import Percentage
-from austin_tui.model.system import SystemModel
+from austin_tui.model.system import Bytes, FrozenSystemModel, Percentage, SystemModel
 from austin_tui.view import View
 from austin_tui.widgets.graph import FlameGraphData
-from austin_tui.widgets.markup import AttrString
-from austin_tui.widgets.markup import escape
+from austin_tui.widgets.markup import AttrString, escape
 from austin_tui.widgets.table import TableData
 
 
@@ -248,7 +243,11 @@ class ThreadDataAdapter(BaseThreadDataAdapter):
         thread_key = austin.threads[austin.current_thread]
         pid, _, thread = thread_key.partition(":")
 
-        thread_stats = austin.stats.processes[int(pid)].threads[thread]
+        pid, _, thread_name = thread_key.partition(":")
+        iid, _, thread = thread_name.partition(":")
+        thread_stats = austin.stats.processes[int(pid)].threads[
+            ThreadName(thread, int(iid))
+        ]
         frames = austin.get_last_stack(thread_key).frames
 
         container = thread_stats.children
@@ -378,9 +377,7 @@ class ThreadFullDataAdapter(BaseThreadDataAdapter):
             )
 
             if level >= MAX_DEPTH or not (
-                children_stats := [
-                    child_stats for _, child_stats in stats.children.items()
-                ]
+                children_stats := list(stats.children.values())
             ):
                 return
 
@@ -403,7 +400,11 @@ class ThreadFullDataAdapter(BaseThreadDataAdapter):
                 active,
             )
 
-        thread_stats = austin.stats.processes[int(pid)].threads[thread]
+        pid, _, thread_name = thread_key.partition(":")
+        iid, _, thread = thread_name.partition(":")
+        thread_stats = austin.stats.processes[int(pid)].threads[
+            ThreadName(thread, int(iid))
+        ]
         if children := list(thread_stats.children.values()):
             for stats in children[:-1]:
                 _add_frame_stats(stats, "├─ ", "│  ", 0, thread_stats.children)
@@ -426,9 +427,9 @@ class FlameGraphAdapter(Adapter):
         self, austin: AustinModel, system: Union[SystemModel, FrozenSystemModel]
     ) -> FlameGraphData:
         thread_key = austin.threads[austin.current_thread]
-        pid, _, thread = thread_key.partition(":")
-
-        thread = austin.stats.processes[int(pid)].threads[thread]
+        pid, _, thread_name = thread_key.partition(":")
+        iid, _, thread = thread_name.partition(":")
+        thread = austin.stats.processes[int(pid)].threads[ThreadName(thread, int(iid))]
 
         cs = {}  # type: ignore[var-annotated]
         total = thread.total

--- a/austin_tui/controller.py
+++ b/austin_tui/controller.py
@@ -22,9 +22,12 @@
 
 import asyncio
 from enum import Enum
-from io import StringIO
+from pathlib import Path
 from time import time
 from typing import Any
+
+from austin.events import AustinMetadata
+from austin.format.mojo import MojoStreamWriter
 
 from austin_tui import AustinProfileMode
 from austin_tui.adapters import Adapter
@@ -253,21 +256,17 @@ class AustinTUIController:
 
         def _dump_stats() -> None:
             pid = self.model.system.child_process.pid
-            filename = f"austin_{int(time())}_{pid}.aprof"
+            output_file = Path(f"austin_{int(time())}_{pid}").with_suffix(".mojo")
             try:
-                buffer = StringIO()
-                model.stats.dump(buffer)
-                with open(filename, "w") as fout:
-                    if self.model.austin.metadata is not None:
-                        for n, v in self.model.austin.metadata.items():
-                            fout.write(f"# {n}: {v}\n")
-                        fout.write("\n")
-                    for line in buffer.getvalue().splitlines():
-                        if not line.startswith("# "):
-                            fout.write(line + "\n")
+                with output_file.open("wb") as stream:
+                    mojo_writer = MojoStreamWriter(stream)
+                    for k, v in model.metadata.items():
+                        mojo_writer.write(AustinMetadata(k, v))
+                    for event in model.stats.flatten():
+                        mojo_writer.write(event)
                 self.view.notification.set_text(
                     self.view.markup(
-                        f"Stats saved as <running>{escape(filename)}</running> "
+                        f"Stats saved as <running>{escape(str(output_file))}</running> "
                     )
                 )
             except IOError as e:

--- a/austin_tui/model/austin.py
+++ b/austin_tui/model/austin.py
@@ -126,7 +126,7 @@ class AustinModel:
                 return
             self._stats.update(sample)
             self._stats.timestamp = time()
-            thread_key = f"{sample.pid}:{sample.thread}"
+            thread_key = f"{sample.pid}:{sample.iid}:{sample.thread}"
             self._last_stack[thread_key] = sample
             self._threads.add(thread_key)
         finally:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ classifiers = [
 keywords = ["performance", "profiling", "testing", "development"]
 
 dependencies = [
-  "austin-python~=2.0",
+  "austin-python~=2.1",
   "importlib_resources~=5.10",
   "lxml~=5.0",
   "psutil",


### PR DESCRIPTION
We make the stats dump feature generate MOJO formats instead of the collapsed stack to retain as much profiling information as possible (e.g. column-level location information).
