### PR TITLE
chore: drop 3.9 and add 3.14

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
     name: Tests with Python ${{ matrix.python-version }} on Linux
     steps:
@@ -24,9 +24,10 @@ jobs:
         with:
           path: main
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}-dev
+          allow-prereleases: true
 
       - name: Checkout Austin development branch
         uses: actions/checkout@master
@@ -67,7 +68,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
     name: Tests with Python ${{ matrix.python-version }} on MacOS
     steps:
@@ -75,9 +76,10 @@ jobs:
         with:
           path: main
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}-dev
+          allow-prereleases: true
 
       - name: Checkout Austin development branch
         uses: actions/checkout@master
@@ -108,7 +110,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
     name: Tests with Python ${{ matrix.python-version }} on Windows
     steps:
@@ -116,9 +118,10 @@ jobs:
         with:
           path: main
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}-dev
+          allow-prereleases: true
 
       - name: Checkout Austin development branch
         uses: actions/checkout@master

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,11 +32,11 @@ classifiers = [
   "Development Status :: 5 - Production/Stable",
   "Intended Audience :: Developers",
   "License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)",
-  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
 ]
 keywords = ["performance", "profiling", "testing", "development"]
 
@@ -67,7 +67,7 @@ template = "tests"
 tests = "pytest --cov=austin --cov-report=term-missing --cov-report=xml {args}"
 
 [[tool.hatch.envs.tests.matrix]]
-python = ["3.9", "3.10", "3.11", "3.12", "3.13"]
+python = ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
 [tool.hatch.envs.checks]
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ keywords = ["performance", "profiling", "testing", "development"]
 dependencies = [
   "austin-python~=2.1",
   "importlib_resources~=5.10",
-  "lxml~=5.0",
+  "lxml>=5.0",
   "psutil",
   "windows-curses~=2.1; sys_platform == 'win32'",
 ]


### PR DESCRIPTION
We drop support for 3.9 and add support for 3.14.

Fixes #46.