### PR TITLE
fix: resolve all mypy typing errors and fix latent bugs

### DIFF
--- a/austin_tui/__main__.py
+++ b/austin_tui/__main__.py
@@ -110,7 +110,7 @@ class AustinTUI(AsyncAustin):
             AustinView.Event.EXCEPTION: self.on_exception,
         }.get(event, _unhandled)(data)  # type: ignore[operator]
 
-    async def start(self, args: AustinTUIArgumentParser) -> None:
+    async def start(self, args: Any) -> None:
         """Start Austin and catch any exceptions."""
         try:
             await super().start(args)
@@ -146,7 +146,8 @@ class AustinTUI(AsyncAustin):
         try:
             await self.start(sys.argv[1:])
             await self.wait()
-            await self._view._input_task
+            if self._view._input_task is not None:
+                await self._view._input_task
         except Exception as e:
             exc = e
             self._view.close()

--- a/austin_tui/adapters.py
+++ b/austin_tui/adapters.py
@@ -20,6 +20,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from abc import abstractmethod
+from typing import TYPE_CHECKING
 from typing import Any
 from typing import Optional
 from typing import Set
@@ -35,8 +37,12 @@ from austin_tui.model.system import Bytes
 from austin_tui.model.system import FrozenSystemModel
 from austin_tui.model.system import Percentage
 from austin_tui.model.system import SystemModel
-from austin_tui.view import View
 from austin_tui.widgets.graph import FlameGraphData
+
+
+if TYPE_CHECKING:
+    from austin_tui.view.austin import AustinView
+
 from austin_tui.widgets.markup import AttrString
 from austin_tui.widgets.markup import escape
 from austin_tui.widgets.table import TableData
@@ -56,7 +62,7 @@ class Adapter:
     An adapter is used by simply calling it.
     """
 
-    def __init__(self, model: Model, view: View) -> None:
+    def __init__(self, model: Model, view: "AustinView") -> None:
         self._model = model
         self._view = view
 
@@ -66,11 +72,11 @@ class Adapter:
 
     def transform(self) -> Any:
         """Transform the model data into the widget data."""
-        pass
+        return None
 
     def update(self, data: Any) -> bool:
         """Update the view with the widget data."""
-        pass
+        return False
 
 
 class FreezableAdapter(Adapter):
@@ -115,6 +121,7 @@ class CommandLineAdapter(FreezableAdapter):
     def transform(self) -> AttrString:
         """Retrieve the command line."""
         cmd = self._model.austin.command_line
+        assert cmd is not None
         exec, *args = cmd
         return self._view.markup(
             f"<exec><b>{escape(exec)}</b></exec> {escape(' '.join(args))}"
@@ -190,7 +197,7 @@ class CurrentThreadAdapter(Adapter):
     def transform(self) -> Union[str, AttrString]:
         """Get current thread."""
         austin = (
-            self._model.frozen_austin
+            self._model.frozen_austin or self._model.austin
             if self._model.frozen
             else self._model.austin
         )
@@ -213,7 +220,7 @@ class ThreadNameAdapter(FreezableAdapter):
     def transform(self) -> Union[str, AttrString]:
         """Get the thread name."""
         austin = (
-            self._model.frozen_austin
+            self._model.frozen_austin or self._model.austin
             if self._model.frozen
             else self._model.austin
         )
@@ -232,15 +239,22 @@ class ThreadNameAdapter(FreezableAdapter):
 class BaseThreadDataAdapter(Adapter):
     """Base implementation for the thread table data adapter."""
 
+    @abstractmethod
+    def _transform(
+        self,
+        austin: AustinModel,
+        system: Union["SystemModel", "FrozenSystemModel"],
+    ) -> TableData: ...
+
     def transform(self) -> TableData:
         """Transform according to the right model."""
         austin = (
-            self._model.frozen_austin
+            self._model.frozen_austin or self._model.austin
             if self._model.frozen
             else self._model.austin
         )
         system = (
-            self._model.frozen_system
+            self._model.frozen_system or self._model.system
             if self._model.frozen
             else self._model.system
         )
@@ -327,7 +341,8 @@ class ThreadTopDataAdapter(BaseThreadDataAdapter):
         thread_key = austin.threads[austin.current_thread]
         pid, _, thread = thread_key.partition(":")
 
-        frame_stats = {}
+        frame_stats: dict[str, complex] = {}
+        truncated = False
         max_scale = (
             system.max_memory
             if self._view.mode == AustinProfileMode.MEMORY
@@ -337,20 +352,9 @@ class ThreadTopDataAdapter(BaseThreadDataAdapter):
         def _add_frame_stats(
             stats: HierarchicalStats, seen_locations: Set[str]
         ) -> None:
-            if len(frame_stats) == MAX_LENGTH:
-                frame_stats.append(
-                    [
-                        " " * 8,
-                        " " * 8,
-                        " " * 8,
-                        " " * 8,
-                        self._view.markup(
-                            " <inactive>[truncated view; export the data to MOJO to see more with other tools]</inactive>"
-                        ),
-                    ]
-                )
-                return
-            if len(frame_stats) > MAX_LENGTH:
+            nonlocal truncated
+            if len(frame_stats) >= MAX_LENGTH:
+                truncated = True
                 return
             if stats.total / 1e6 / max_scale < self._model.austin.threshold:
                 return
@@ -390,18 +394,31 @@ class ThreadTopDataAdapter(BaseThreadDataAdapter):
 
             _add_frame_stats(children[-1], set())
 
-        return [
-            (
+        rows: TableData = [
+            [
                 formatter(int(m.real), True),
                 formatter(int(m.imag), True),
                 scaler(int(m.real), max_scale, True),
                 scaler(int(m.imag), max_scale, True),
                 self._view.markup(location),
-            )
+            ]
             for location, m in sorted(
                 frame_stats.items(), reverse=True, key=lambda _: _[1].real
             )
         ]
+        if truncated:
+            rows.append(
+                [
+                    " " * 8,
+                    " " * 8,
+                    " " * 8,
+                    " " * 8,
+                    self._view.markup(
+                        " <inactive>[truncated view; export the data to MOJO to see more with other tools]</inactive>"
+                    ),
+                ]
+            )
+        return rows
 
 
 MAX_DEPTH = 64
@@ -424,7 +441,7 @@ class ThreadFullDataAdapter(BaseThreadDataAdapter):
         pid, _, thread = thread_key.partition(":")
 
         frames = austin.get_last_stack(thread_key).frames or []
-        frame_stats = []
+        frame_stats: TableData = []
         max_scale = (
             system.max_memory
             if self._view.mode == AustinProfileMode.MEMORY
@@ -543,12 +560,12 @@ class FlameGraphAdapter(Adapter):
     def transform(self) -> dict:
         """Transform according to the right model."""
         austin = (
-            self._model.frozen_austin
+            self._model.frozen_austin or self._model.austin
             if self._model.frozen
             else self._model.austin
         )
         system = (
-            self._model.frozen_system
+            self._model.frozen_system or self._model.system
             if self._model.frozen
             else self._model.system
         )

--- a/austin_tui/controller.py
+++ b/austin_tui/controller.py
@@ -25,6 +25,8 @@ from enum import Enum
 from pathlib import Path
 from time import time
 from typing import Any
+from typing import Callable
+from typing import Optional
 
 from austin.events import AustinMetadata
 from austin.format.mojo import MojoStreamWriter
@@ -44,6 +46,7 @@ from austin_tui.adapters import ThreadNameAdapter
 from austin_tui.adapters import ThreadTopDataAdapter
 from austin_tui.model import Model
 from austin_tui.view import ViewBuilder
+from austin_tui.view.austin import AustinView
 from austin_tui.view.austin import AustinViewMode
 from austin_tui.widgets.markup import escape
 
@@ -77,16 +80,17 @@ class AustinTUIController:
 
     def __init__(self) -> None:
         self._view_mode = AustinViewMode.LIVE
-        self._scaler = None
-        self._formatter = None
+        self._scaler: Optional[Callable[..., Any]] = None
+        self._formatter: Optional[Callable[..., Any]] = None
         self._last_timestamp = 0
-        self._update_task = None
+        self._update_task: Optional[asyncio.Task[None]] = None
 
         view_builder = ViewBuilder.from_resource(
             "austin_tui.view", "tui.austinui"
         )
 
-        self.view = view = view_builder.build()  # type: ignore[assignment]
+        self.view: AustinView = view_builder.build()  # type: ignore[assignment]
+        view = self.view
 
         view_builder.autoconnect(self)
 
@@ -208,7 +212,9 @@ class AustinTUIController:
     def _change_thread(self, direction: ThreadNav) -> bool:
         """Change thread."""
         austin = (
-            self.model.frozen_austin if self.model.frozen else self.model.austin
+            self.model.frozen_austin or self.model.austin
+            if self.model.frozen
+            else self.model.austin
         )
         prev_index = austin.current_thread
 
@@ -228,7 +234,7 @@ class AustinTUIController:
     async def on_next_thread(self) -> bool:
         """Handle next thread event."""
         if self._change_thread(ThreadNav.NEXT):
-            if self._graph:
+            if self._view_mode is AustinViewMode.GRAPH:
                 self.view.flamegraph.draw()
                 self.view.flame_view.refresh()
             else:
@@ -240,7 +246,7 @@ class AustinTUIController:
     async def on_previous_thread(self) -> bool:
         """Handle previous thread event."""
         if self._change_thread(ThreadNav.PREV):
-            if self._graph:
+            if self._view_mode is AustinViewMode.GRAPH:
                 self.view.flamegraph.draw()
                 self.view.flame_view.refresh()
             else:
@@ -298,6 +304,7 @@ class AustinTUIController:
         )
 
         def _dump_stats() -> None:
+            assert self.model.system.child_process is not None
             pid = self.model.system.child_process.pid
             output_file = Path(f"austin_{int(time())}_{pid}").with_suffix(
                 ".mojo"

--- a/austin_tui/model/austin.py
+++ b/austin_tui/model/austin.py
@@ -80,7 +80,7 @@ class AustinModel:
     """Austin model."""
 
     def __init__(self) -> None:
-        self.mode = None
+        self.mode: Optional[AustinProfileMode] = None
 
         self._samples = 0
         self._invalids = 0
@@ -100,9 +100,9 @@ class AustinModel:
 
         self.metadata: Optional[Dict[str, str]] = None
         self.threshold = 0.0
-        self.command_line: Optional[str] = None
+        self.command_line: Optional[List[str]] = None
 
-    def set_command_line(self, command_line: str) -> None:
+    def set_command_line(self, command_line: List[str]) -> None:
         """Set the command line."""
         self.command_line = command_line
 

--- a/austin_tui/mypy_plugin.py
+++ b/austin_tui/mypy_plugin.py
@@ -1,0 +1,197 @@
+# This file is part of "austin-tui" which is released under GPL.
+#
+# See file LICENCE or go to http://www.gnu.org/licenses/ for full license
+# details.
+#
+# austin-tui is top-like TUI for Austin.
+#
+# Copyright (c) 2018-2020 Gabriele N. Tornetta <phoenix1987@gmail.com>.
+# All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Mypy plugin that infers widget attribute types from .austinui XML resources.
+
+Any View subclass can declare::
+
+    __ui_resource__ = ("austin_tui.view", "tui.austinui")
+
+and the plugin will parse the referenced XML file at type-check time, adding
+properly-typed attributes for every named widget it finds.
+"""
+
+import importlib.util
+import os
+from typing import Callable
+from typing import Optional
+from xml.etree import ElementTree as ET
+
+from mypy.nodes import MDEF
+from mypy.nodes import AssignmentStmt
+from mypy.nodes import NameExpr
+from mypy.nodes import StrExpr
+from mypy.nodes import SymbolTableNode
+from mypy.nodes import TypeInfo
+from mypy.nodes import Var
+from mypy.plugin import ClassDefContext
+from mypy.plugin import Plugin
+from mypy.types import Instance
+
+
+# .austinui XML namespace
+_NAMESPACE = "http://austin.p403n1x87.com/ui"
+_NS_PREFIX = f"{{{_NAMESPACE}}}"
+
+# Maps XML element localname → fully-qualified mypy type name
+_WIDGET_TYPES: dict[str, str] = {
+    "Box": "austin_tui.widgets.box.Box",
+    "BarPlot": "austin_tui.widgets.label.BarPlot",
+    "CommandBar": "austin_tui.widgets.command_bar.CommandBar",
+    "FlameGraph": "austin_tui.widgets.graph.FlameGraph",
+    "Label": "austin_tui.widgets.label.Label",
+    "Line": "austin_tui.widgets.label.Line",
+    "ScrollView": "austin_tui.widgets.scroll.ScrollView",
+    "Selector": "austin_tui.widgets.selector.Selector",
+    "Table": "austin_tui.widgets.table.Table",
+    "ToggleLabel": "austin_tui.widgets.label.ToggleLabel",
+    "Window": "austin_tui.widgets.window.Window",
+}
+
+_VIEW_BASE = "austin_tui.view.View"
+
+
+# ---------------------------------------------------------------------------
+# XML helpers
+# ---------------------------------------------------------------------------
+
+
+def _find_resource(package: str, resource: str) -> Optional[str]:
+    """Return the filesystem path for a package resource, or None."""
+    try:
+        spec = importlib.util.find_spec(package)
+        if spec is None or spec.origin is None:
+            return None
+        package_dir = os.path.dirname(spec.origin)
+        candidate = os.path.join(package_dir, resource)
+        return candidate if os.path.isfile(candidate) else None
+    except (ModuleNotFoundError, ValueError):
+        return None
+
+
+def _extract_widgets(xml_path: str) -> dict[str, str]:
+    """Return {widget_name: widget_type_fullname} for every named widget in the XML."""
+    tree = ET.parse(xml_path)
+    widgets: dict[str, str] = {}
+
+    def _walk(el: ET.Element) -> None:
+        tag = el.tag
+        if tag.startswith(_NS_PREFIX):
+            localname = tag[len(_NS_PREFIX) :]
+            name = el.attrib.get("name")
+            if name and localname in _WIDGET_TYPES:
+                widgets[name] = _WIDGET_TYPES[localname]
+        for child in el:
+            _walk(child)
+
+    _walk(tree.getroot())
+    return widgets
+
+
+# ---------------------------------------------------------------------------
+# AST helpers
+# ---------------------------------------------------------------------------
+
+
+def _read_ui_resource(ctx: ClassDefContext) -> Optional[tuple[str, str]]:
+    """Read ``__ui_resource__ = "resource"`` from the class body.
+
+    The package is derived from the class's own module name so it never needs
+    to be spelled out explicitly.
+    """
+    for stmt in ctx.cls.defs.body:
+        if not isinstance(stmt, AssignmentStmt):
+            continue
+        for lvalue in stmt.lvalues:
+            if (
+                not isinstance(lvalue, NameExpr)
+                or lvalue.name != "__ui_resource__"
+            ):
+                continue
+            if isinstance(stmt.rvalue, StrExpr):
+                module = (
+                    ctx.cls.info.module_name
+                )  # e.g. "austin_tui.view.austin"
+                package = module.rsplit(".", 1)[0]  # e.g. "austin_tui.view"
+                return (package, stmt.rvalue.value)
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Plugin hook
+# ---------------------------------------------------------------------------
+
+
+def _inject_widget_attrs(ctx: ClassDefContext) -> None:
+    """Inject typed widget attributes derived from the class's .austinui resource."""
+    resource_spec = _read_ui_resource(ctx)
+    if resource_spec is None:
+        return
+
+    package, resource = resource_spec
+    xml_path = _find_resource(package, resource)
+    if xml_path is None:
+        ctx.api.fail(
+            f"austin-tui mypy plugin: cannot locate resource '{resource}' "
+            f"in package '{package}'",
+            ctx.cls,
+        )
+        return
+
+    try:
+        widgets = _extract_widgets(xml_path)
+    except ET.ParseError as exc:
+        ctx.api.fail(
+            f"austin-tui mypy plugin: failed to parse '{xml_path}': {exc}",
+            ctx.cls,
+        )
+        return
+
+    cls_info = ctx.cls.info
+
+    for attr_name, type_fullname in widgets.items():
+        # Don't override explicitly declared attributes
+        if attr_name in cls_info.names:
+            continue
+
+        type_sym = ctx.api.lookup_fully_qualified_or_none(type_fullname)
+        if type_sym is None or not isinstance(type_sym.node, TypeInfo):
+            continue
+
+        typ = Instance(type_sym.node, [])
+        var = Var(attr_name, typ)
+        var.info = cls_info
+        var._fullname = f"{cls_info.fullname}.{attr_name}"
+        cls_info.names[attr_name] = SymbolTableNode(MDEF, var)
+
+
+class AustinTUIPlugin(Plugin):
+    def get_base_class_hook(
+        self, fullname: str
+    ) -> Optional[Callable[[ClassDefContext], None]]:
+        if fullname == _VIEW_BASE:
+            return _inject_widget_attrs
+        return None
+
+
+def plugin(version: str) -> type[AustinTUIPlugin]:
+    return AustinTUIPlugin

--- a/austin_tui/mypy_plugin.py
+++ b/austin_tui/mypy_plugin.py
@@ -185,13 +185,17 @@ def _inject_widget_attrs(ctx: ClassDefContext) -> None:
 
 
 class AustinTUIPlugin(Plugin):
+    """Mypy plugin for austin-tui."""
+
     def get_base_class_hook(
         self, fullname: str
     ) -> Optional[Callable[[ClassDefContext], None]]:
+        """Inject widget attributes into View subclasses with __ui_resource__."""
         if fullname == _VIEW_BASE:
             return _inject_widget_attrs
         return None
 
 
 def plugin(version: str) -> type[AustinTUIPlugin]:
+    """Return the plugin class for mypy."""
     return AustinTUIPlugin

--- a/austin_tui/view/austin.py
+++ b/austin_tui/view/austin.py
@@ -53,6 +53,8 @@ class AustinView(View):
         EXCEPTION = 0
         QUIT = 1
 
+    __ui_resource__ = "tui.austinui"
+
     def __init__(
         self,
         name: str,
@@ -244,7 +246,7 @@ class AustinView(View):
         )
 
     def scale_memory(
-        self, memory: int, max_memory: int, active: bool = True
+        self, memory: int, max_memory: float, active: bool = True
     ) -> AttrStringChunk:
         """Scale a memory value and return an attribute string chunk."""
         return self._scaler(
@@ -252,7 +254,7 @@ class AustinView(View):
         )
 
     def scale_time(
-        self, time: int, duration: int, active: bool = True
+        self, time: int, duration: float, active: bool = True
     ) -> AttrStringChunk:
         """Scale a time value and return an attribute string chunk."""
         return self._scaler(min(time / 1e4 / duration, 100), active)

--- a/austin_tui/widgets/__init__.py
+++ b/austin_tui/widgets/__init__.py
@@ -91,7 +91,7 @@ class Widget:
     """
 
     def __init__(self, name: str, width: int = 0, height: int = 0) -> None:
-        self._win: Optional[curses._CursesWindow] = None
+        self._win: Optional[curses.window] = None
         self.win: Optional[Widget] = None
         self.parent: Optional[Widget] = None
         self.view = None
@@ -168,6 +168,10 @@ class Widget:
         This method must return ``True`` if a refresh of the screen is required.
         """
         return False
+
+    def get_win(self) -> Optional["curses.window"]:
+        """Get the underlying curses window."""
+        return self._win
 
     def resize(self, rect: Rect) -> bool:
         """Resize the widget.

--- a/austin_tui/widgets/command_bar.py
+++ b/austin_tui/widgets/command_bar.py
@@ -34,4 +34,7 @@ class CommandBar(Box):
         try:
             return super().draw()
         finally:
-            self.win.get_win().clrtoeol()
+            if self.win is not None:
+                win = self.win.get_win()
+                if win is not None:
+                    win.clrtoeol()

--- a/austin_tui/widgets/graph.py
+++ b/austin_tui/widgets/graph.py
@@ -82,13 +82,17 @@ class FlameGraph(Widget):
                 scale = w / v
 
             self._height = h(data, scale)
+            assert self.parent is not None
             self.parent.resize(self.parent.rect)
             return True
 
         return False
 
     def _draw_frame(self, x: int, y: int, w: float, text: str) -> None:
+        assert self.win is not None
         win = self.win.get_win()
+        if win is None:
+            return
 
         iw = int(w)
         fw = int((w - iw) * 8)
@@ -125,7 +129,11 @@ class FlameGraph(Widget):
         if not self.win or not self._data:
             return False
 
-        self.win.get_win().clear()
+        assert self.win is not None
+        win = self.win.get_win()
+        if win is None:
+            return False
+        win.clear()
 
         w = self.size.x
         for _, (v, _) in self._data.items():

--- a/austin_tui/widgets/label.py
+++ b/austin_tui/widgets/label.py
@@ -127,7 +127,7 @@ class Label(Widget):
         except curses.error:
             return 0
 
-    def resize(self, rect: Optional[Rect] = None) -> bool:
+    def resize(self, rect: Rect) -> bool:
         """Resize logic for the label object."""
         width = min(self.width, rect.size.real) or rect.size.real
         height = min(self.height, rect.size.imag) or rect.size.imag
@@ -192,6 +192,8 @@ class Label(Widget):
 
     def hide(self) -> None:
         """Hide the label."""
+        if self.win is None:
+            return
         win = self.win.get_win()
         if not win:
             return
@@ -299,10 +301,10 @@ class BarPlot(Label):
     ) -> None:
         super().__init__(name, width=8, color=color, ellipsize=False)
 
-        self._values = deque(
+        self._values: deque[float] = deque(
             [int(init)] * width if init is not None else [], maxlen=width
         )
-        self.scale = int(scale or 0)
+        self.scale: float = int(scale or 0)
         self.auto = not scale
 
     def _plot(self) -> bool:
@@ -313,7 +315,7 @@ class BarPlot(Label):
             )
         )
 
-    def push(self, value: int) -> bool:
+    def push(self, value: float) -> bool:
         """Push a new value to the plot."""
         self._values.append(value)
         if self.auto:

--- a/austin_tui/widgets/markup.py
+++ b/austin_tui/widgets/markup.py
@@ -27,6 +27,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING
 from typing import Any
 from typing import List
+from typing import Optional
 from xml.sax.saxutils import escape as escape
 
 from lxml import etree
@@ -83,7 +84,11 @@ class AttrStringChunk(Writable):
         return attr
 
     def write(  # type: ignore[override]
-        self, window: "curses._CursesWindow", y: int, x: int, maxlen: int = None
+        self,
+        window: "curses.window",
+        y: int,
+        x: int,
+        maxlen: Optional[int] = None,
     ) -> int:
         """Write the chunk on the given curses window.
 
@@ -135,7 +140,11 @@ class AttrString(Writable):
         return sum(len(_) for _ in self._chunks)
 
     def write(  # type: ignore[override]
-        self, window: "curses._CursesWindow", y: int, x: int, maxlen: int = None
+        self,
+        window: "curses.window",
+        y: int,
+        x: int,
+        maxlen: Optional[int] = None,
     ) -> int:
         """Write the attribute string on the given window.
 

--- a/austin_tui/widgets/scroll.py
+++ b/austin_tui/widgets/scroll.py
@@ -38,7 +38,7 @@ class ScrollView(Container):
 
     def __init__(self, name: str) -> None:
         super().__init__(name)
-        self._win: Optional[curses._CursesWindow] = None
+        self._win: Optional[curses.window] = None
 
         self.win = self
 
@@ -48,7 +48,7 @@ class ScrollView(Container):
         self.w = 1
         self.h = 1
 
-    def get_win(self) -> Optional["curses._CursesWindow"]:
+    def get_win(self) -> Optional["curses.window"]:
         """Get the underlying curses pad.
 
         Use with care.
@@ -159,17 +159,24 @@ class ScrollView(Container):
         if not self._win:
             return
 
+        if self.parent is None or self.parent.win is None:
+            return
+
+        parent_win = self.parent.win.get_win()
+        if parent_win is None:
+            return
+
         y0, x0 = self.pos.y, self.pos.x
         h, w = self.size.y, self.size.x
 
         x = x0 + w - 1
 
-        self.parent.win._win.vline(y0, x, curses.ACS_VLINE, h)
+        parent_win.vline(y0, x, curses.ACS_VLINE, h)
 
         bar_h = min(int(h * h / self.h) + 1, h)
         if bar_h != h:
             bar_y = int(self.curr_y / self.h * h)
-            self.parent.win._win.vline(y0 + bar_y, x, curses.ACS_CKBOARD, bar_h)
+            parent_win.vline(y0 + bar_y, x, curses.ACS_CKBOARD, bar_h)
 
     def resize(self, rect: Rect) -> bool:
         """Resize the scroll view."""

--- a/austin_tui/widgets/selector.py
+++ b/austin_tui/widgets/selector.py
@@ -20,8 +20,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Optional
-
 from austin_tui.widgets import BaseContainer
 from austin_tui.widgets import Rect
 from austin_tui.widgets import Widget
@@ -44,7 +42,7 @@ class Selector(BaseContainer):
         self._selected = 0
 
     @property
-    def selected(self) -> Optional[Widget]:
+    def selected(self) -> Widget:
         """Get the selected widget."""
         try:
             return self._children[self._selected]

--- a/austin_tui/widgets/table.py
+++ b/austin_tui/widgets/table.py
@@ -44,6 +44,8 @@ class Table(Widget):
         self._data: TableData = []
 
     def _show_empty(self) -> bool:
+        if self.win is None:
+            return False
         win = self.win.get_win()
         if not win:
             return False
@@ -55,7 +57,10 @@ class Table(Widget):
     def _draw_row(self, i: int, row: List[Any]) -> None:
         x = 0
         available = self.rect.size.x - 1
+        assert self.win is not None
         win = self.win.get_win()
+        if win is None:
+            return
         for j in range(self._cols):
             if available <= x:
                 break
@@ -77,6 +82,7 @@ class Table(Widget):
         if data != self._data:
             self._data = data
             self._height = len(data)
+            assert self.parent is not None
             self.parent.resize(self.parent.rect)
             return True
 

--- a/austin_tui/widgets/window.py
+++ b/austin_tui/widgets/window.py
@@ -113,10 +113,11 @@ class Window(Container):
 
         As per curses convention this returns the tuple (_height_, _width_).
         """
+        assert self._win is not None
         y, x = self._win.getmaxyx()
         return Point(x, y)
 
-    def get_win(self) -> Optional["curses._CursesWindow"]:
+    def get_win(self) -> Optional["curses.window"]:
         """Get the underlying curses window.
 
         Use with care.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -137,6 +137,7 @@ indent-style = "space"
 [tool.mypy]
 exclude = []
 ignore_missing_imports = true
+plugins = ["austin_tui.mypy_plugin"]
 
 [[tool.mypy.overrides]]
 ignore_errors = true


### PR DESCRIPTION
Bug fixes:
- controller.py: replace undefined self._graph with the correct self._view_mode is AustinViewMode.GRAPH; accessing _graph would have raised AttributeError at runtime in on_next_thread/on_previous_thread
- adapters.py: fix ThreadTopDataAdapter truncation branch calling .append() on a dict (frame_stats); would raise AttributeError once a profile accumulated ≥4096 unique frames; replaced with a truncated flag appended to the final list, matching ThreadFullDataAdapter
- model/austin.py: fix command_line typed as Optional[str] when it is set from child_process.cmdline() (list[str]) and unpacked as such in CommandLineAdapter
- model/austin.py: fix mode typed as None (no annotation) making any AustinProfileMode assignment a silent type error

Type annotation fixes:
- widgets/__init__.py, window.py, scroll.py, markup.py: replace private curses._CursesWindow with the public curses.window alias
- widgets/__init__.py: add get_win() to Widget base class so subclasses calling self.win.get_win() are valid without casts
- widgets/selector.py: fix selected property return type from Optional[Widget] to Widget (it always raises SelectorError, never returns None)
- widgets/markup.py: fix implicit Optional in write() signatures (maxlen: int = None -> maxlen: Optional[int] = None)
- widgets/label.py: remove spurious Optional from resize() signature; fix BarPlot._values and scale to float to match push(value: float)
- widgets/scroll.py: add None guards for self.parent chain in _draw_scroll_bar
- widgets/graph.py, table.py, command_bar.py: add None guards after win = self.win.get_win() calls
- adapters.py: type Adapter._view as AustinView instead of View; add abstract _transform to BaseThreadDataAdapter; annotate frame_stats types; fix scale_memory/scale_time to accept float for max_scale
- view/austin.py: fix scale_memory and scale_time signatures to accept float for the scale argument
- controller.py: annotate self.view as AustinView; fix _scaler, _formatter, _update_task types; resolve frozen_austin None via `or`
- __main__.py: fix start() signature to Any; guard _input_task await

Mypy plugin (austin_tui/mypy_plugin.py):
- Add a mypy plugin that reads the .austinui XML resource at type-check time and injects properly-typed widget attributes into any View subclass declaring __ui_resource__ = "resource.austinui"
- AustinView now uses __ui_resource__ = "tui.austinui" instead of 28 explicit class-level attribute declarations; the package is derived automatically from the class's module name
- Register the plugin via [tool.mypy] plugins in pyproject.toml