### PR TITLE
feat: process picker

### DIFF
--- a/austin_tui/__main__.py
+++ b/austin_tui/__main__.py
@@ -26,6 +26,7 @@ import sys
 from austin.errors import AustinError
 
 from austin_tui.controller import AustinTUIController
+from austin_tui.picker import pick_python_process
 
 
 class AustinTUI:
@@ -51,12 +52,35 @@ class AustinTUI:
             raise
 
 
+def _needs_picker() -> bool:
+    """Return True when no target process or command was specified."""
+    # Flags that consume the next token as their value.
+    value_flags = {"-i", "--interval", "-x", "--exposure", "-t", "--timeout"}
+    it = iter(sys.argv[1:])
+    for arg in it:
+        if arg in value_flags:
+            next(it, None)
+        elif arg.startswith(("-p", "--pid", "--open")):
+            return False  # explicit PID or file specified
+        elif not arg.startswith("-"):
+            return False  # positional command found
+    return True
+
+
 def main() -> None:
     """Main function."""
     if sys.platform == "win32":
         asyncio.set_event_loop(asyncio.ProactorEventLoop())
 
+    if _needs_picker():
+        pid = pick_python_process()
+        if pid is None:
+            exit(0)
+        sys.argv = [sys.argv[0], "-p", str(pid)]
+
     tui = AustinTUI()
+
+    import os
 
     try:
         tui.run()
@@ -68,15 +92,20 @@ def main() -> None:
             "variable and that the command line arguments that you have provided are correct.",
             file=sys.stderr,
         )
-        import os
+    except ValueError:
+        print(
+            "❌ Austin produced no output. If you are attaching to an existing process,\n"
+            "   try running austin-tui with sudo.",
+            file=sys.stderr,
+        )
+    else:
+        exit(0)
 
-        if os.environ.get("AUSTIN_DEBUG", None) is not None:
-            import traceback
+    if os.environ.get("AUSTIN_DEBUG", None) is not None:
+        import traceback
 
-            traceback.print_exc()
-        exit(-1)
-
-    exit(0)
+        traceback.print_exc()
+    exit(-1)
 
 
 if __name__ == "__main__":

--- a/austin_tui/picker.py
+++ b/austin_tui/picker.py
@@ -1,0 +1,202 @@
+# This file is part of "austin-tui" which is released under GPL.
+#
+# See file LICENCE or go to http://www.gnu.org/licenses/ for full license
+# details.
+#
+# austin-tui is top-like TUI for Austin.
+#
+# Copyright (c) 2018-2020 Gabriele N. Tornetta <phoenix1987@gmail.com>.
+# All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import asyncio
+from typing import List
+from typing import NamedTuple
+from typing import Optional
+from typing import cast
+
+import psutil
+
+from austin_tui.view import EventHandler
+from austin_tui.view import View
+from austin_tui.view import ViewBuilder
+from austin_tui.view.palette import Palette
+from austin_tui.widgets.markup import AttrString
+from austin_tui.widgets.markup import AttrStringChunk
+
+
+class PythonProcess(NamedTuple):
+    """A Python process entry for the picker."""
+
+    pid: int
+    name: str
+    cmdline: List[str]
+
+
+def _get_python_processes() -> List[PythonProcess]:
+    procs = []
+    for proc in psutil.process_iter(["pid", "name", "cmdline"]):
+        try:
+            name = proc.info["name"] or ""
+            if "python" not in name.lower():
+                continue
+            cmdline: List[str] = proc.info["cmdline"] or []
+            procs.append(PythonProcess(proc.info["pid"], name, cmdline))
+        except (psutil.NoSuchProcess, psutil.AccessDenied):
+            continue
+    return sorted(procs, key=lambda p: p.pid)
+
+
+def _pid_cell(pid: int, color: int, selected: bool) -> AttrString:
+    astr = AttrString()
+    astr.append(AttrStringChunk(f"{pid:>7}", color, False, selected))
+    astr.append(AttrStringChunk("  ", 0, False, selected))
+    return astr
+
+
+def _cmdline_cell(proc: PythonProcess, palette: Palette, selected: bool) -> AttrString:
+    """Build a syntax-highlighted AttrString for a process command line.
+
+    Colors:
+      proc_exec  — executable basename (bold)
+      proc_path  — directory prefix of executable
+      proc_flag  — tokens starting with -
+      proc_arg   — positional args / option values
+    """
+    astr = AttrString()
+    tokens = proc.cmdline if proc.cmdline else [proc.name]
+
+    for i, token in enumerate(tokens):
+        if i == 0:
+            slash = token.rfind("/")
+            if slash >= 0:
+                path_c = palette.get_color("proc_path")
+                exec_c = palette.get_color("proc_exec")
+                astr.append(AttrStringChunk(token[: slash + 1], path_c, False, selected))
+                astr.append(AttrStringChunk(token[slash + 1 :], exec_c, True, selected))
+            else:
+                exec_c = palette.get_color("proc_exec")
+                astr.append(AttrStringChunk(token, exec_c, True, selected))
+        elif token.startswith("-"):
+            flag_c = palette.get_color("proc_flag")
+            astr.append(AttrStringChunk(token, flag_c, False, selected))
+        else:
+            arg_c = palette.get_color("proc_arg")
+            astr.append(AttrStringChunk(token, arg_c, False, selected))
+
+        if i < len(tokens) - 1:
+            astr.append(AttrStringChunk(" ", 0, False, selected))
+
+    return astr
+
+
+class PickerView(View):
+    """Interactive process picker view."""
+
+    def __init__(self, name: str) -> None:
+        super().__init__(name)
+        self._processes: List[PythonProcess] = []
+        self._selected: int = 0
+        self._selected_pid: Optional[int] = None
+
+    @property
+    def selected_pid(self) -> Optional[int]:
+        """The PID chosen by the user, or None if the picker was dismissed."""
+        return self._selected_pid
+
+    def populate(self, processes: List[PythonProcess]) -> None:
+        """Load the process list and render the initial table."""
+        self._processes = processes
+        self._selected = 0
+        self._refresh_table()
+
+    def _refresh_table(self) -> None:
+        palette = self.palette
+        pid_color = palette.get_color("proc_pid")
+        data = [
+            [
+                _pid_cell(proc.pid, pid_color, i == self._selected),
+                _cmdline_cell(proc, palette, i == self._selected),
+            ]
+            for i, proc in enumerate(self._processes)
+        ]
+        self.proc_table.set_data(data)  # type: ignore[attr-defined]
+        self.proc_table.draw()  # type: ignore[attr-defined]
+        self.proc_scroll.refresh()  # type: ignore[attr-defined]
+
+    async def on_up(self) -> bool:
+        """Move selection up."""
+        if self._selected > 0:
+            self._selected -= 1
+            self._refresh_table()
+            scroll = self.proc_scroll  # type: ignore[attr-defined]
+            if self._selected < scroll.curr_y:
+                scroll.scroll_up()
+            return True
+        return False
+
+    async def on_down(self) -> bool:
+        """Move selection down."""
+        if self._selected < len(self._processes) - 1:
+            self._selected += 1
+            self._refresh_table()
+            scroll = self.proc_scroll  # type: ignore[attr-defined]
+            if self._selected >= scroll.curr_y + scroll.size.y:
+                scroll.scroll_down()
+            return True
+        return False
+
+    async def on_select(self) -> bool:
+        """Confirm selection and close the picker."""
+        if self._processes:
+            self._selected_pid = self._processes[self._selected].pid
+        self.close()
+        return False
+
+    async def on_quit(self) -> bool:
+        """Dismiss the picker without selecting."""
+        self.close()
+        return False
+
+
+async def _run_picker(view: PickerView, processes: List[PythonProcess]) -> None:
+    view.open()
+    view.populate(processes)
+    assert view.root_widget is not None
+    view.root_widget.refresh()
+    if view._input_task is not None:
+        try:
+            await view._input_task
+        except asyncio.CancelledError:
+            pass
+
+
+def pick_python_process() -> Optional[int]:
+    """Show an interactive process picker. Returns the chosen PID or None."""
+    processes = _get_python_processes()
+    if not processes:
+        return None
+
+    builder = ViewBuilder.from_resource("austin_tui.view", "picker.austinui")
+    view: PickerView = builder.build()  # type: ignore[assignment]
+    builder.autoconnect()
+    # "\n" and "\r" can't be expressed as XML attribute values, so wire Enter manually.
+    _select = cast(EventHandler, view.on_select)
+    view.connect("\n", _select)
+    view.connect("\r", _select)
+    view.connect("KEY_ENTER", _select)
+
+    asyncio.run(_run_picker(view, processes))
+
+    return view.selected_pid

--- a/austin_tui/view/picker.austinui
+++ b/austin_tui/view/picker.austinui
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<!-- This file is part of "austin-tui" which is released under GPL.
+
+See file LICENCE or go to http://www.gnu.org/licenses/ for full license
+details.
+
+austin-tui is top-like TUI for Austin.
+
+Copyright (c) 2018-2020 Gabriele N. Tornetta <phoenix1987@gmail.com>.
+All rights reserved.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>. -->
+
+<aui:PickerView xmlns:aui="http://austin.p403n1x87.com/ui" name="picker">
+  <aui:Window name="main">
+    <aui:Box name="main_box" flow="vertical">
+
+      <!-- Header: logo on the left, subtitle on the right -->
+      <aui:Box name="header_box" flow="horizontal">
+
+        <aui:Box name="logo_box" flow="vertical">
+          <aui:Label name="title"
+            text="Austin  TUI"
+            align="center"
+            width="15"
+            height="1"
+            bold="true" />
+          <aui:Label name="logo"
+            text="_________\n⎝__⎠ ⎝__⎠"
+            align="center"
+            width="15"
+            height="3"
+            color="logo"
+            bold="true" />
+        </aui:Box>
+
+        <aui:Box name="subtitle_box" flow="vertical">
+          <aui:Label name="subtitle"
+            text="  Select a Python process to profile"
+            color="picker_header"
+            height="1" />
+        </aui:Box>
+
+      </aui:Box>
+
+      <!-- Process list -->
+      <aui:ScrollView name="proc_scroll">
+        <aui:Table name="proc_table" columns="2" />
+      </aui:ScrollView>
+
+      <!-- Command bar -->
+      <aui:CommandBar name="command_bar">
+        <aui:Label name="up_cmd"    text="↑"      width="3"  align="center" color="cmd_key" />
+        <aui:Label name="up_lbl"    text="Up"     width="4"                               />
+        <aui:Label name="down_cmd"  text="↓"      width="3"  align="center" color="cmd_key" />
+        <aui:Label name="down_lbl"  text="Down"   width="6"                               />
+        <aui:Label name="enter_cmd" text="↵"      width="3"  align="center" color="cmd_key" />
+        <aui:Label name="enter_lbl" text="Select" width="8"                               />
+        <aui:Label name="quit_cmd"  text="q"      width="3"  align="center" color="cmd_key" />
+        <aui:Label name="quit_lbl"  text="Quit"   width="5"                               />
+      </aui:CommandBar>
+
+    </aui:Box>
+  </aui:Window>
+
+  <!-- Signal mappings -->
+  <aui:signal key="KEY_UP"   handler="on_up"   />
+  <aui:signal key="KEY_DOWN" handler="on_down" />
+  <aui:signal key="q"        handler="on_quit" />
+  <aui:signal key="Q"        handler="on_quit" />
+
+  <!-- Palette -->
+  <!-- See https://github.com/gookit/color/blob/c7dc09464b28518c2ae383fa16b989e7c0169599/_examples/images/color-256.png -->
+
+  <aui:palette>
+    <!-- Header -->
+    <aui:color name="logo"          fg="1"   />
+    <aui:color name="picker_header" fg="246" />
+
+    <!-- Command bar -->
+    <aui:color name="cmd_key" bg="18" />
+
+    <!-- Process list syntax highlighting -->
+    <aui:color name="proc_pid"  fg="229" />  <!-- warm yellow: PID number -->
+    <aui:color name="proc_path" fg="242" />  <!-- dim gray: directory prefix -->
+    <aui:color name="proc_exec" fg="10"  />  <!-- bright green: executable name -->
+    <aui:color name="proc_flag" fg="226" />  <!-- yellow: flags and options -->
+    <aui:color name="proc_arg"  fg="251" />  <!-- light gray: positional args -->
+  </aui:palette>
+</aui:PickerView>

--- a/tests/mcurses.py
+++ b/tests/mcurses.py
@@ -9,7 +9,7 @@ class MWindow:
     def addstr(self, *args, **kwargs):
         pass
 
-    def refresh(self):
+    def refresh(self, *args, **kwargs):
         pass
 
     def resize(self, *args, **kwargs):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,10 +1,6 @@
 import sys
 from contextlib import contextmanager
 
-import pytest
-
-from austin_tui.__main__ import main
-
 
 @contextmanager
 def override_argv(args):
@@ -16,8 +12,3 @@ def override_argv(args):
         sys.argv = original_argv
 
 
-def test_main_no_args(capsys):
-    with pytest.raises(SystemExit) as e, override_argv(["austin-tui"]):
-        main()
-    assert e.value.code == -1
-    assert "No PID" in capsys.readouterr().err

--- a/tests/test_view.py
+++ b/tests/test_view.py
@@ -1,4 +1,5 @@
 from austin_tui.view import ViewBuilder
+from austin_tui.view.austin import AustinView  # noqa: F401
 from austin_tui.widgets import Rect
 from tests.mcurses import MWindow
 


### PR DESCRIPTION
When the TUI is launched with no arguments, a list of potential Python processes is displayed. The user can pick one to attach and collect profiles.

Addresses #2.