### PR TITLE
fix: time formatting

### DIFF
--- a/austin_tui/adapters.py
+++ b/austin_tui/adapters.py
@@ -180,7 +180,7 @@ def fmt_time(us: int) -> str:
     """Format microseconds into [mm]m[ss[.ff]]s."""
     s = us / 1e6
     m = int(s // 60)
-    return f"{m:02d}m{int(s):02d}s" if m else f"{s:.2f}s"
+    return f"{m:02d}m{int(s) % 60:02d}s" if m else f"{s:.2f}s"
 
 
 class DurationAdapter(FreezableAdapter):

--- a/tests/test_fmt_time.py
+++ b/tests/test_fmt_time.py
@@ -1,0 +1,21 @@
+import pytest
+
+from austin_tui.adapters import fmt_time
+
+
+@pytest.mark.parametrize(
+    "us, expected",
+    [
+        (0, "0.00s"),
+        (500_000, "0.50s"),
+        (1_000_000, "1.00s"),
+        (59_000_000, "59.00s"),
+        (60_000_000, "01m00s"),
+        (61_000_000, "01m01s"),
+        (90_500_000, "01m30s"),
+        (3_600_000_000, "60m00s"),
+        (3_661_000_000, "61m01s"),
+    ],
+)
+def test_fmt_time(us: int, expected: str) -> None:
+    assert fmt_time(us) == expected


### PR DESCRIPTION
Fixed an issue with how time metric is formatted. The number of seconds was not being represented % 60 and so it kept increasing along with the other time components.